### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=IrServiceBase
+version=1.0.0
+author=sle118, probonopd
+maintainer=sle118
+sentence=Defines a framework for creating TCP/IP based infrared client/servers with ESP8266.
+paragraph=
+category=Communication
+url=https://github.com/sle118/IrServiceBase
+architectures=esp8266


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the Arduino Library Manager index.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata